### PR TITLE
404 only redirect

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -83,7 +83,6 @@
                         console.error(err);
                         rej(err);
                     } else {
-                        console.log("upserting");
                         domainStore.upsert(domainData.id, domainData, function(err) {
                             if (err) {
                                 console.error(err);
@@ -217,9 +216,6 @@
     };
 
     var handleRequest = function(requestUrl, tabUrl, tabId, statusCode) {
-        console.log(requestUrl);
-        console.log(tabUrl);
-        console.log(tabId);
         for (var key in ruleDomains) {
             var domainObj = ruleDomains[key];
             if (domainObj.on && match(domainObj.matchUrl, tabUrl).matched) {
@@ -321,7 +317,6 @@
             var domainObj = ruleDomains[key];
             if (domainObj.on && match(domainObj.matchUrl, tabUrl).matched) {
                 var rules = domainObj.rules || [];
-                console.log("there is a match on domain");
                 for (var x = 0, len = rules.length; x < len; ++x) {
                     var ruleObj = rules[x];
                     if (ruleObj.on && ruleObj.type === "headerRule") {
@@ -473,10 +468,8 @@
                     tabUrl = details.url;
                 }
                 if (tabUrl) {
-                    console.log("on before request of",details.url);
                     var result = handleRequest(details.url, tabUrl, details.tabId);
                     //If result (obj), if has a redirect url key within it
-                    console.log("result",result);
                     if (result) {
                         // make sure we don't try to redirect again.
                         requestIdTracker.push(details.requestId);
@@ -497,31 +490,19 @@
         urls: ["<all_urls>"]
     }, ["blocking", "requestHeaders"]);
 
-    chrome.webRequest.onResponseStarted.addListener(
-        function(details){
-            console.log("ON response started DETAILS:",details);
-        }, {
-        urls: ["<all_urls>"]
-    });
-
     chrome.webRequest.onHeadersReceived.addListener(
         function(details){
-            console.log("headers received details",details);
             if(details.statusCode===404){
-                console.log("404-evaluating redirect now");
                 if (!requestIdTracker.has(details.requestId)) {
                     if (details.tabId > -1) {
-                        console.log("made it here");
                         var tabUrl = tabUrlTracker.getUrlFromId(details.tabId);
                         if (details.type === "main_frame") {
                             // a new tab must have just been created.
                             tabUrl = details.url;
                         }
                         if (tabUrl) {
-                            console.log("on before request of",details.url);
                             var result = handleRequest(details.url, tabUrl, details.tabId, details.statusCode);
                             //If result (obj), if has a redirect url key within it
-                            console.log("result",result);
                             if (result) {
                                 // make sure we don't try to redirect again.
                                 requestIdTracker.push(details.requestId);
@@ -534,20 +515,6 @@
         }, {
         urls: ["<all_urls>"]
     }, ["blocking", "responseHeaders"]);
-
-    chrome.webRequest.onCompleted.addListener(
-        function(details){
-            console.log("ON COMPLETED DETAILS:",details);
-        }, {
-        urls: ["<all_urls>"]
-    });
-
-    chrome.webRequest.onErrorOccurred.addListener(
-        function(details){
-            console.log("ERROR OCCURRED DETAILS:",details);
-        }, {
-        urls: ["<all_urls>"]
-    });
 
     //init settings
     if (localStorage.devTools === undefined) {

--- a/src/ui/css/on-off-switch.css
+++ b/src/ui/css/on-off-switch.css
@@ -29,7 +29,7 @@ https://proto.io/freebies/onoff/
 }
 .onoffswitch-inner {
     display: block; width: 200%; margin-left: -100%;
-    -moz-transition: margin 0.3s ease-in 0s; -webkit-transition: margin 0.3s ease-in 0s;
+    -moz-transition: margin 0.3ss ease-in 0s; -webkit-transition: margin 0.3ss ease-in 0s;
     -o-transition: margin 0.3s ease-in 0s; transition: margin 0.3s ease-in 0s;
 }
 .onoffswitch-on {
@@ -58,9 +58,12 @@ https://proto.io/freebies/onoff/
     display: block; width: 18px; margin: 6px;
     background: #FFFFFF;
     border: 2px solid #999999; border-radius: 5px;
-    position: absolute; top: 0; bottom: 0; right: 46px;
-    -moz-transition: all 0.3s ease-in 0s; -webkit-transition: all 0.3s ease-in 0s;
-    -o-transition: all 0.3s ease-in 0s; transition: all 0.3s ease-in 0s;
+    position: absolute; top: 0; bottom: 0; 
+    right: 46px;
+    /*right:calc(100% - 40);*/
+    /*right:67%;*/
+    -moz-transition: all .3s ease-in 0s; -webkit-transition: all .3s ease-in 0s;
+    -o-transition: all .3s ease-in 0s; transition: all .3s ease-in 0s;
 }
 .onoffswitch-checkbox:checked + .onoffswitch-label .onoffswitch-inner {
     margin-left: 0;

--- a/src/ui/css/on-off-switch.css
+++ b/src/ui/css/on-off-switch.css
@@ -29,7 +29,7 @@ https://proto.io/freebies/onoff/
 }
 .onoffswitch-inner {
     display: block; width: 200%; margin-left: -100%;
-    -moz-transition: margin 0.3ss ease-in 0s; -webkit-transition: margin 0.3ss ease-in 0s;
+    -moz-transition: margin 0.3s ease-in 0s; -webkit-transition: margin 0.3s ease-in 0s;
     -o-transition: margin 0.3s ease-in 0s; transition: margin 0.3s ease-in 0s;
 }
 .onoffswitch-on {
@@ -58,10 +58,7 @@ https://proto.io/freebies/onoff/
     display: block; width: 18px; margin: 6px;
     background: #FFFFFF;
     border: 2px solid #999999; border-radius: 5px;
-    position: absolute; top: 0; bottom: 0; 
-    right: 46px;
-    /*right:calc(100% - 40);*/
-    /*right:67%;*/
+    position: absolute; top: 0; bottom: 0; right: 46px;
     -moz-transition: all .3s ease-in 0s; -webkit-transition: all .3s ease-in 0s;
     -o-transition: all .3s ease-in 0s; transition: all .3s ease-in 0s;
 }

--- a/src/ui/devtoolstab.html
+++ b/src/ui/devtoolstab.html
@@ -21,7 +21,6 @@
         </label>
     </div>
 </template>
-
 <template id="domainTemplate">
     <div class="domainContainer">
         <div class="domainHeader">
@@ -65,8 +64,12 @@
             <input type="input" class="replaceInput" placeholder="Replace URL">
         </div>
         <div class="switch">
+            <on-off-switch class="allOr404Only" onText="All" offText="404s"></on-off-switch>
+        </div>
+        <div class="switch">
             <on-off-switch class="ruleOnOff"></on-off-switch>
         </div>
+        
         <div class="delete">
             <button class="btn sym-btn">&#215</button>
         </div>

--- a/src/ui/devtoolstab.js
+++ b/src/ui/devtoolstab.js
@@ -26,7 +26,6 @@
                 const newDomain = app.createDomainMarkup({rules: [{type: "normalOverride"}]});
                 ui.domainDefs.append(newDomain);
                 newDomain.find(".domainMatchInput").val("*");
-                console.log("domain data is here",app.getDomainData(newDomain));
                 chrome.extension.sendMessage({
                     action: "saveDomain",
                     data: app.getDomainData(newDomain)

--- a/src/ui/devtoolstab.js
+++ b/src/ui/devtoolstab.js
@@ -26,6 +26,7 @@
                 const newDomain = app.createDomainMarkup({rules: [{type: "normalOverride"}]});
                 ui.domainDefs.append(newDomain);
                 newDomain.find(".domainMatchInput").val("*");
+                console.log("domain data is here",app.getDomainData(newDomain));
                 chrome.extension.sendMessage({
                     action: "saveDomain",
                     data: app.getDomainData(newDomain)

--- a/src/ui/onOffSwitch.js
+++ b/src/ui/onOffSwitch.js
@@ -10,15 +10,13 @@
             createdCallback: {
 
                 value: function() {
-                    console.log("this",this);
                     this.createShadowRoot().appendChild(document.importNode(
                         ui.onOffSwitchTemplate[0].content, true));
                     const $switchContainer = $(this.shadowRoot.children[1]);
-                    console.log("switchcontainer", $switchContainer);
                     $switchContainer.find(".onoffswitch-on").text(
                         this.getAttribute("onText") || "ON");
                     $switchContainer.find(".onoffswitch-off").text(
-                        this.getAttribute("offText") ||"OFF");
+                        this.getAttribute("offText") || "OFF");
                     this.checkbox = $switchContainer.find("input");
                 }
             },

--- a/src/ui/onOffSwitch.js
+++ b/src/ui/onOffSwitch.js
@@ -8,14 +8,17 @@
     document.registerElement("on-off-switch", {
         prototype: Object.create(HTMLElement.prototype, {
             createdCallback: {
+
                 value: function() {
+                    console.log("this",this);
                     this.createShadowRoot().appendChild(document.importNode(
                         ui.onOffSwitchTemplate[0].content, true));
                     const $switchContainer = $(this.shadowRoot.children[1]);
+                    console.log("switchcontainer", $switchContainer);
                     $switchContainer.find(".onoffswitch-on").text(
                         this.getAttribute("onText") || "ON");
                     $switchContainer.find(".onoffswitch-off").text(
-                        this.getAttribute("offText") || "OFF");
+                        this.getAttribute("offText") ||"OFF");
                     this.checkbox = $switchContainer.find("input");
                 }
             },

--- a/src/ui/tabGroup.js
+++ b/src/ui/tabGroup.js
@@ -52,15 +52,24 @@
     }
 
     function getDomainData(domain) {
+        console.log("GET DOMAIN DATA");
         const rules = [];
         domain.find(".ruleContainer").each(function(idx, el) {
             const $el = $(el);
             if ($el.hasClass("normalOverride")) {
+                console.log("getdomaindata",{
+                    type: "normalOverride",
+                    match: $el.find(".matchInput").val(),
+                    replace: $el.find(".replaceInput").val(),
+                    on: $el.find(".ruleOnOff")[0].isOn,
+                    all:$el.find(".allOr404Only")[0].isOn
+                });
                 rules.push({
                     type: "normalOverride",
                     match: $el.find(".matchInput").val(),
                     replace: $el.find(".replaceInput").val(),
-                    on: $el.find(".ruleOnOff")[0].isOn
+                    on: $el.find(".ruleOnOff")[0].isOn,
+                    all:$el.find(".allOr404Only")[0].isOn
                 });
             } else if ($el.hasClass("fileOverride")) {
                 rules.push({

--- a/src/ui/tabGroup.js
+++ b/src/ui/tabGroup.js
@@ -52,18 +52,10 @@
     }
 
     function getDomainData(domain) {
-        console.log("GET DOMAIN DATA");
         const rules = [];
         domain.find(".ruleContainer").each(function(idx, el) {
             const $el = $(el);
             if ($el.hasClass("normalOverride")) {
-                console.log("getdomaindata",{
-                    type: "normalOverride",
-                    match: $el.find(".matchInput").val(),
-                    replace: $el.find(".replaceInput").val(),
-                    on: $el.find(".ruleOnOff")[0].isOn,
-                    all:$el.find(".allOr404Only")[0].isOn
-                });
                 rules.push({
                     type: "normalOverride",
                     match: $el.find(".matchInput").val(),

--- a/src/ui/webRule.js
+++ b/src/ui/webRule.js
@@ -21,6 +21,7 @@
         util.makeFieldRequired(matchInput);
         util.makeFieldRequired(replaceInput);
         ruleOnOff[0].isOn = savedData.on === false ? false : true;
+        allOr404Only[0].isOn = savedData.all === false ? false : true;
 
         if (savedData.on === false) {
             override.addClass("disabled");
@@ -51,6 +52,7 @@
             saveFunc();
         });
         allOr404Only.on("click change", function() {
+            override.toggleClass("disabled", !allOr404Only[0].isOn);
             saveFunc();
         });
 

--- a/src/ui/webRule.js
+++ b/src/ui/webRule.js
@@ -13,6 +13,7 @@
         const matchInput = override.find(".matchInput");
         const replaceInput = override.find(".replaceInput");
         const ruleOnOff = override.find(".ruleOnOff");
+        const allOr404Only = override.find(".allOr404Only");
         const deleteBtn = override.find(".sym-btn");
 
         matchInput.val(savedData.match || "");
@@ -47,6 +48,9 @@
         replaceInput.on("keyup", saveFunc);
         ruleOnOff.on("click change", function() {
             override.toggleClass("disabled", !ruleOnOff[0].isOn);
+            saveFunc();
+        });
+        allOr404Only.on("click change", function() {
             saveFunc();
         });
 


### PR DESCRIPTION
Perhaps you don't have all of the site's static assets (images,css,js,*) on you local computer. With this, if the request header status code is a 404, you can redirect it to the production site.  For me, our sites images and other uploaded user generated content is kept out of our repos. Therefore, when I clone the site's repo and create a local instance of the database, I don't have to copy all the various locations files are uploaded to my local computer nor have to create numerous resource override regex rules for the various resource url patterns. Instead, I just have something along the lines of `*localsiteinstance.com*` -> `*productionsiteinstance.com*` and apply to 404s only. 
![image](https://user-images.githubusercontent.com/1644131/28346863-a393069e-6c01-11e7-9ddf-057ac7ee91a8.png)

After using these modifications for a couple months, the only issue at the moment that I've noticed is having it redirect json requests that are 404s.  They do redirect, but I'm not applying CORS header (yet) and the browser's security blocks it.  For the moment, I'm getting around the CORS issue with https://chrome.google.com/webstore/detail/allow-control-allow-origi/nlfbmbojpeacfghkpbjhddihlkkiljbi  Not sure if the cors header should be applied automatically by ResourceOverride. After all, there would be security implications for the users and I didn't want to introduce those yet. In order to address it in the future though, perhaps an additional toggle that they'll have to enable to disable cors for the applied regex on by modifying the headers OnHeadersReceived?