### PR TITLE
Feature/badge count

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Resource Override",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "An extension to help you gain full control of any website by redirecting traffic, replacing, editing, or inserting new content.",
   "icons": {
     "16": "icons/icon-16x16.png",

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -51,6 +51,7 @@
             closeListeners.forEach(function(fn) {
                 fn(urls[tabId]);
             });
+            badgeMap.delete(tabId);
             delete urls[tabId];
         };
 

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -5,6 +5,7 @@
 
     var ruleDomains = {};
     var syncFunctions = [];
+    var badgeMap = new Map();
 
     var logOnTab = function(tabId, message, important) {
         if (localStorage.showLogs === "true") {

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -34,6 +34,8 @@
 
         var updateTabCallback = function(tabId, changeinfo, tab) {
             urls[tabId] = tab.url;
+            badgeMap.set(tabId, 0);
+            updateBadge(details.tabId, '');
         };
 
         // Not all tabs will fire an update event. If the page is pre-rendered,

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -358,6 +358,13 @@
         return headerObjToReturn;
     };
 
+    var updateBadge = function(tabId, text) {
+        if (localStorage.showBadgeCount === "false") return;
+        var color = '#099';
+        chrome.browserAction.setBadgeText(text && { text, tabId });
+        chrome.browserAction.setBadgeBackgroundColor({ color, tabId });
+    };
+
     // Called when the user clicks on the browser action icon.
     chrome.browserAction.onClicked.addListener(function(tab) {
         openOrFocusOptionsPage();

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -228,6 +228,9 @@
                             var matchedObj = match(ruleObj.match, requestUrl);
                             var newUrl = matchReplace(matchedObj, ruleObj.replace, requestUrl);
                             if (matchedObj.matched) {
+                                var badgeCount = badgeMap.get(tabId) || 0;
+                                badgeMap.set(tabId, ++badgeCount);
+                                updateBadge(tabId, '' + badgeCount);
                                 logOnTab(tabId, "URL Override Matched: " + requestUrl +
                                     "   to:   " + newUrl + "   match url: " + ruleObj.match, true);
                                 if (requestUrl !== newUrl) {
@@ -240,6 +243,10 @@
                             }
                         } else if (ruleObj.type === "fileOverride" &&
                             match(ruleObj.match, requestUrl).matched) {
+
+                            var badgeCount = badgeMap.get(tabId) || 0;
+                            badgeMap.set(tabId, ++badgeCount);
+                            updateBadge(tabId, '' + badgeCount);
 
                             logOnTab(tabId, "File Override Matched: " + requestUrl + "   match url: " +
                                 ruleObj.match, true);

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -35,7 +35,7 @@
         var updateTabCallback = function(tabId, changeinfo, tab) {
             urls[tabId] = tab.url;
             badgeMap.set(tabId, 0);
-            updateBadge(details.tabId, '');
+            updateBadge(tabId, '');
         };
 
         // Not all tabs will fire an update event. If the page is pre-rendered,

--- a/src/ui/devtoolstab.html
+++ b/src/ui/devtoolstab.html
@@ -209,6 +209,10 @@
             <div class="optionCheckbox"><input type="checkbox" id="showDevTools"></div>
         </div>
         <div class="optionRow">
+            <div class="optionText">Show Badge Count:</div>
+            <div class="optionCheckbox"><input type="checkbox" id="showBadgeCount"></div>
+        </div>
+        <div class="optionRow">
             <div class="optionText" id="showSuggestionsText">Show Suggestions:</div>
             <div class="optionCheckbox"><input type="checkbox" id="showSuggestions"></div>
         </div>

--- a/src/ui/options.js
+++ b/src/ui/options.js
@@ -44,6 +44,14 @@
         });
     });
 
+    ui.showBadgeCount.on("click", function(e) {
+        chrome.extension.sendMessage({
+            action: "setSetting",
+            setting: "showBadgeCount",
+            value: ui.showBadgeCount.prop("checked")
+        });
+    });
+
     ui.saveRulesLink.on("click", function(e) {
         e.preventDefault();
         const data = app.export();
@@ -98,6 +106,13 @@
         setting: "showLogs"
     }, function(data) {
         ui.showLogs.prop("checked", data === "true");
+    });
+
+    chrome.extension.sendMessage({
+        action: "getSetting",
+        setting: "showBadgeCount"
+    }, function(data) {
+        ui.showBadgeCount.prop("checked", data === "true");
     });
 
 })();


### PR DESCRIPTION
This will give the user an option to show a badge over the extension icon that will contain a count of matched rules found on a specific tab.

I have found myself leaving rules enabled that unknowingly cause me issues.  I wanted there to be a visual cue that something might be getting applied on a given page that could be the root cause of these issues.