### PR TITLE
Fixed replacement of data.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,6 +7,11 @@
     "48": "icons/icon-48x48.png",
     "128": "icons/icon-128x128.png"
   },
+  "applications" : {
+    "gecko" : {
+      "id" : "ResourceOverride@kylepaulsen.com"
+    }
+  },
   "browser_action": {
     "default_icon": {
       "16": "icons/icon-16x16.png"

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -99,7 +99,7 @@
                     tabUrl = details.url;
                 }
                 if (tabUrl) {
-                    const result = bgapp.handleRequest(details.url, tabUrl, details.tabId);
+                    const result = bgapp.handleRequest(details.url, tabUrl, details.tabId, details.requestId);
                     if (result) {
                         // make sure we don't try to redirect again.
                         bgapp.requestIdTracker.push(details.requestId);


### PR DESCRIPTION
Replacement was not working because of a bug in Firefox staying for more than 9 years. Also noticed a flaw in design - we cannot replace binary files since assumme they are text ones. But it is shouldn't be fixed in this PR.