### PR TITLE
Only update tabUrlTracker on URL change

### DIFF
--- a/src/background/tabUrlTracker.js
+++ b/src/background/tabUrlTracker.js
@@ -15,7 +15,9 @@
         };
 
         const updateTabCallback = function(tabId, changeinfo, tab) {
-            urls[tabId] = tab.url;
+            if (changeinfo.url) {
+                urls[tabId] = changeinfo.url;
+            }
         };
 
         // Not all tabs will fire an update event. If the page is pre-rendered,


### PR DESCRIPTION
Hello! I love this extension!

I've been running into a difficult-to-reproduce bug where sometimes a tab update doesn't contain a `url` property, and the tracked url for that tab gets set to `undefined`, causing all rules to fail to match within that tab.

Though intermittent, it appears to only happen when I have other extensions turned on (React DevTools might be a culprit). Whatever the cause, the Chrome API does seem to specify that [the `url` property can be unset on a Tab](https://developer.chrome.com/docs/extensions/reference/tabs/#property-Tab-url) if the tab hasn't "committed", whatever that means.

In any case, it's fixable by looking at the `changeinfo` object for the `url` property and skipping the update if it hasn't changed - which should also make for fewer updates to the `tabUrlTracker`, so this seems like a net win all round.